### PR TITLE
fix: Instancesのブロックが数秒後に消える不具合を修正

### DIFF
--- a/src/app/(main)/_components/fog-ground.tsx
+++ b/src/app/(main)/_components/fog-ground.tsx
@@ -313,7 +313,11 @@ export default function FogGround() {
         style={{
           position: "fixed",
           inset: 0,
-          zIndex: 0,
+          // 背景の霧。ページのコンテンツ(見出しやInstancesの3D)より必ず後ろに敷く。
+          // 0のままだと、位置指定された霧canvasが非位置指定のコンテンツより前に描画され、
+          // template のフェードイン(site-wrapperのopacity)完了後にInstancesのブロックを覆い隠す。
+          // Instancesの3D canvas(zIndex:-1)より更に後ろに置く。
+          zIndex: -2,
           pointerEvents: "none",
         }}
       />


### PR DESCRIPTION
## 概要

`/instances` でブロックが表示された後、**約3秒で消えてしまう**不具合を修正します。

## 原因

physics（落下）やカメラではなく、**不透明な霧の背景レイヤーがブロックを覆い隠していた**ことが原因でした。

`fog-ground.tsx` の霧canvasは、
- 全画面 `position: fixed; inset: 0`
- **`zIndex: 0`**
- シェーダ出力が `gl_FragColor = vec4(col, 1.0)` = **完全不透明**

という設定で、Instancesの3D canvas（ラッパーBoxが `zIndex: -1`）や見出しの**手前**に描画されていました。

### なぜ「3秒後」なのか

`template.tsx` の framer-motion フェードイン（`.site-wrapper` の opacity 0→1, `duration: 4`）が関係します。

1. **フェード中**は `opacity < 1` が**スタッキングコンテキストを生成**し、その中のInstances 3Dが霧より前面に持ち上がる → ブロックが見える
2. **フェード完了（opacity=1）**でスタッキングコンテキストが消滅 → 不透明な霧canvasが前面に戻る → **ブロックが覆われて消える**

これが「表示 → 約3秒後に消える」の正体です。

## 検証

- `cannon-es`（同じ物理エンジン）でヘッドレスにシミュレート → ブロックは約2秒で床に着地し**安定**（トンネル・爆散なし）
- `three` のカメラ投影で計算 → 着地位置は**画面中央に写り、見えるはず** → 物理・フレーミングは正常
- 実ブラウザで霧canvasを非表示にすると見出し・影が出現することを確認 → 犯人は霧の被せと断定

## 修正

霧は背景レイヤーなので、コンテンツより常に後ろに敷くように **`zIndex: 0` → `-2`** に変更（Instancesの3D canvas `-1` よりさらに後ろ）。実質1行の変更です。

### 動作確認

- **Instances**: 霧が背景に回り、見出し・3Dシーンが前面に。フェード完了後もブロックが消えないことを確認。
- **トップ**: 霧・タイトル・縦書きテキスト・`shio` 透かし（mixBlendMode）すべて正常。リグレッションなし。

## 補足（本PRの対象外）

`InstancesView` のブロック本体はライティングが弱く暗め（スポットライト1灯・ambientなし）で、はっきり見えるのは主に床の影でした。今回の不具合とは無関係な既存の見た目のため本PRでは触れていません。くっきり見せたい場合は別途 `ambientLight` 追加等で対応可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)